### PR TITLE
Adding a search bar to filter layers

### DIFF
--- a/load_lyrs_from_geohub_services.py
+++ b/load_lyrs_from_geohub_services.py
@@ -35,7 +35,8 @@ from qgis.PyQt.QtWidgets import (
     QScrollArea, 
     QWidget,
     QCheckBox,
-    QLineEdit
+    QLineEdit,
+    QFrame
     )
 from qgis.PyQt.QtCore import Qt
 from qgis import processing
@@ -491,6 +492,7 @@ class LayerSelectionDialog(QDialog):
 
         # Search bar
         self.search_bar = QLineEdit()
+        self.search_bar.setPlaceholderText("Type to filter layers...")
         self.search_bar.textChanged.connect(self.update_display)
         self.no_result = QLabel("No layers found")
         
@@ -500,6 +502,11 @@ class LayerSelectionDialog(QDialog):
         # Add radio buttons to the layout
         layout.addWidget(self.radio_layer_bbox)
         layout.addWidget(self.radio_canvas_bbox)
+
+        line = QFrame()
+        line.setFrameShape(QFrame.HLine)
+        line.setFrameShadow(QFrame.Sunken)
+        layout.addWidget(line)
 
         # Add search bar to layout
         layout.addWidget(self.search_bar)

--- a/load_lyrs_from_geohub_services.py
+++ b/load_lyrs_from_geohub_services.py
@@ -492,6 +492,7 @@ class LayerSelectionDialog(QDialog):
         # Search bar
         self.search_bar = QLineEdit()
         self.search_bar.textChanged.connect(self.update_display)
+        self.no_result = QLabel("No layers found")
         
         # Set default selection
         self.radio_canvas_bbox.setChecked(True)
@@ -502,6 +503,7 @@ class LayerSelectionDialog(QDialog):
 
         # Add search bar to layout
         layout.addWidget(self.search_bar)
+        
 
         # Make it scrollable for layers
         scroll_area = QScrollArea()
@@ -522,7 +524,9 @@ class LayerSelectionDialog(QDialog):
             self.checkboxes.append(checkbox)
 
         scroll_area.setWidget(widget)
+        scroll_layout.addWidget(self.no_result)
         layout.addWidget(scroll_area)
+        self.no_result.hide()
 
         # Add the OK and Cancel buttons
         button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -556,11 +560,18 @@ class LayerSelectionDialog(QDialog):
             return "canvas_bbox_for_service"
         
     def update_display(self, text):
-        for widget in self.checkboxes:
-            if text.lower() in widget.objectName().lower():
-                widget.show()
+        any_visible = False
+        for checkbox in self.checkboxes:
+            if text.lower() in checkbox.objectName().lower():
+                checkbox.show()
+                self.no_result.hide()
+                any_visible = True
             else:
-                widget.hide()
+                self.no_result.hide()
+                checkbox.hide()
+        
+        if not any_visible:
+            self.no_result.show()
 
 ## END of CLASSES #####################################################################################
 

--- a/load_lyrs_from_geohub_services.py
+++ b/load_lyrs_from_geohub_services.py
@@ -34,7 +34,8 @@ from qgis.PyQt.QtWidgets import (
     QRadioButton, 
     QScrollArea, 
     QWidget,
-    QCheckBox
+    QCheckBox,
+    QLineEdit
     )
 from qgis.PyQt.QtCore import Qt
 from qgis import processing
@@ -487,6 +488,10 @@ class LayerSelectionDialog(QDialog):
         # Radio buttons to choose between bbox functions
         self.radio_layer_bbox = QRadioButton("Select polygon layer for bbox")
         self.radio_canvas_bbox = QRadioButton("Use canvas for bbox")
+
+        # Search bar
+        self.search_bar = QLineEdit()
+        self.search_bar.textChanged.connect(self.update_display)
         
         # Set default selection
         self.radio_canvas_bbox.setChecked(True)
@@ -494,6 +499,9 @@ class LayerSelectionDialog(QDialog):
         # Add radio buttons to the layout
         layout.addWidget(self.radio_layer_bbox)
         layout.addWidget(self.radio_canvas_bbox)
+
+        # Add search bar to layout
+        layout.addWidget(self.search_bar)
 
         # Make it scrollable for layers
         scroll_area = QScrollArea()
@@ -508,6 +516,7 @@ class LayerSelectionDialog(QDialog):
         self.checkboxes = []
         for layer in layers:
             checkbox = QCheckBox(layer[1])
+            checkbox.setObjectName(layer[1])
             checkbox.setChecked(False)  # By default, no layers are selected
             scroll_layout.addWidget(checkbox)
             self.checkboxes.append(checkbox)
@@ -545,6 +554,13 @@ class LayerSelectionDialog(QDialog):
             return "layer_bbox_for_service"
         else:
             return "canvas_bbox_for_service"
+        
+    def update_display(self, text):
+        for widget in self.checkboxes:
+            if text.lower() in widget.objectName().lower():
+                widget.show()
+            else:
+                widget.hide()
 
 ## END of CLASSES #####################################################################################
 


### PR DESCRIPTION
Added functionality:
- There is now a search bar which can be used to filter the layer list - making it easier to find layers (if the layer name is known of course)

If everything is looking good here, we can close Issue #16 

It might be cool in the future to have descriptions of these layers / links to their descriptions on Geohub. I can open that as a separate issue / future enhancement.